### PR TITLE
Report the project which aborted the build

### DIFF
--- a/src/main/java/org/terracotta/jenkins/plugins/acceleratedbuildnow/AcceleratedBuildNowAction.java
+++ b/src/main/java/org/terracotta/jenkins/plugins/acceleratedbuildnow/AcceleratedBuildNowAction.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
+import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -113,7 +114,12 @@ public class AcceleratedBuildNowAction implements Action {
             && !(projectConsidered instanceof MatrixProject) && !(projectConsidered instanceof MatrixConfiguration)) {
           LOG.info("project : " + lastBuild.getProject().getName() + " #" + lastBuild.getNumber() + " was not scheduled by a human, killing it right now to re schedule it later !");
           Executor executor = getExecutor(lastBuild);
-          executor.interrupt(Result.ABORTED);
+          executor.interrupt(Result.ABORTED, new CauseOfInterruption() {
+            @Override
+            public String getShortDescription() {
+              return "Aborted by Accelerated Build Now Plugin. Triggering a new build for project: " + project.getName();
+            }
+          });
           killedBuild = lastBuild;
           break;
         }


### PR DESCRIPTION
The current plugin will abort the build and mention that it was `Aborted by anonymous` which can be confusing unless logging is set to `INFO`. Instead the cause will now mention that it was aborted by the accelerated build now plugin, and the project which triggered the abort.
